### PR TITLE
Require svg

### DIFF
--- a/eplot.el
+++ b/eplot.el
@@ -20,6 +20,7 @@
 
 ;;; Code:
 
+(require 'svg)
 (require 'cl-lib)
 (require 'face-remap)
 


### PR DESCRIPTION
It errors out with `Symbol's function definition is void: svg-create` without this.

I'm using:
GNU Emacs 31.0.50 (build 1, aarch64-apple-darwin23.1.0, NS appkit-2487.20 Version 14.1.1 (Build 23B81)) of 2024-06-24

This library looks fantastic, thanks!
