### PR TITLE
Support Emacs 28 by passing image-scaling-factor to image-compute-scaling-factor

### DIFF
--- a/eplot.el
+++ b/eplot.el
@@ -676,7 +676,7 @@ If RETURN-IMAGE is non-nil, return it instead of displaying it."
       ;; Set the size of the chart based on the window it's going to
       ;; be displayed in.  It uses the *eplot* window by default, or
       ;; the current one if that isn't displayed.
-      (let ((factor (image-compute-scaling-factor)))
+      (let ((factor (image-compute-scaling-factor image-scaling-factor)))
 	(unless width
 	  (setq width (/ (* (window-pixel-width
  			     (get-buffer-window "*eplot*" t))


### PR DESCRIPTION
In Emacs 29 the first argument was made optional and defaults to image-scaling-factor