### PR TITLE
Replace hardcoded /tmp dir with make-temp-file

### DIFF
--- a/eplot.el
+++ b/eplot.el
@@ -1786,7 +1786,7 @@ If RETURN-IMAGE is non-nil, return it instead of displaying it."
       (with-temp-buffer
 	(set-buffer-multibyte nil)
 	(svg-print svg)
-	(let* ((file (concat (make-temp-name "/tmp/eplot") ".svg"))
+	(let* ((file (make-temp-file "eplot" nil ".svg"))
 	       (png (file-name-with-extension file ".png")))
 	  (unwind-protect
 	      (progn


### PR DESCRIPTION
I noticed this when I tried **eplot** today in Emacs on Windows. Using `(make-temp-file)` should be cross-platform if variable `temporary-file-directory` is set properly - the default.